### PR TITLE
Bump `jenkins/inbound-agent` Docker image version to 3309.v27b_9314fd1a_4-3-jdk21-nanoserver-1809

### DIFF
--- a/PodTemplates.d/package-windows.yaml
+++ b/PodTemplates.d/package-windows.yaml
@@ -8,7 +8,7 @@ metadata:
     jenkins/default-release-jenkins-agent: true
 spec:
   containers:
-  - image: "jenkins/inbound-agent:3142.vcfca_0cd92128-1-jdk17-nanoserver-1809"
+  - image: 3309.v27b_9314fd1a_4-3-jdk21-nanoserver-1809
     imagePullPolicy: "IfNotPresent"
     name: "jnlp"
     env:


### PR DESCRIPTION



<Actions>
    <action id="a95016b28e3bae9c96043fccd7be67c21f991509dccdb6202e12a65279bfd1e8">
        <h3>Bump `jenkins/inbound-agent` Docker image version</h3>
        <details id="7ddf2c38fd5d719ac8f397e71e10684ebc1eb0a9fd310385f9685dddbab24d8e">
            <summary>Update jenkins/inbound agent version in package-windows.yaml</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.spec.containers[0].image&#34; updated from &#34;\&#34;jenkins/inbound-agent:3142.vcfca_0cd92128-1-jdk17-nanoserver-1809\&#34;&#34; to &#34;3309.v27b_9314fd1a_4-3-jdk21-nanoserver-1809&#34;, in file &#34;PodTemplates.d/package-windows.yaml&#34;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Jenkins agent container image to use a newer version with JDK 21 on Windows, replacing the previous JDK 17 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->